### PR TITLE
Add mcp-audit to tools — full OWASP MCP Top 10 mapping

### DIFF
--- a/tab_tools.md
+++ b/tab_tools.md
@@ -1,0 +1,13 @@
+---
+title: Tools
+displaytext: Tools
+layout: null
+tab: true
+order: 4
+tags: mcptopten
+---
+
+## Tools
+
+**[mcp-audit](https://github.com/adudley78/mcp-audit)** — Open-source CLI scanner for MCP server configurations. Maps every finding to the OWASP MCP Top 10 via machine-readable owasp-mapping.json with CI enforcement. Covers all 10 categories. SARIF output with OWASP taxonomy relationships for GitHub Code Scanning. Apache 2.0.
+`pip install mcp-audit-scanner` · `mcp-audit check`


### PR DESCRIPTION
mcp-audit is an open-source CLI scanner for MCP server configurations.

What makes it relevant here specifically:
- Maps every finding ID to the OWASP MCP Top 10 via `docs/owasp-mapping.json` (machine-readable, CI-enforced — `validate_owasp_mapping.py` exits 1 on any gap)
- `--owasp-report` flag produces a per-category finding summary across all 10 categories
- SARIF output includes OWASP taxonomy relationships for GitHub Code Scanning
- Covers all 10 categories: MCP01 through MCP10

Apache 2.0. https://github.com/adudley78/mcp-audit

Made with [Cursor](https://cursor.com)