### PR TITLE
MCP05: add SSRF risk and outbound network controls

### DIFF
--- a/2025/MCP05-2025–Command-Injection&Execution.md
+++ b/2025/MCP05-2025–Command-Injection&Execution.md
@@ -20,9 +20,24 @@ MCP tools that wrap system calls, database operations, or file system access bec
 ##### Chained execution: 
 A seemingly benign command can be chained with malicious operators (&&, |, ;, backticks) to execute arbitrary code. Because agents operate autonomously and often with elevated privileges to perform their intended functions, successful command injection can lead to complete system compromise, data exfiltration, or lateral movement across interconnected services. 
 
+##### Tool-mediated server-side request forgery (SSRF):
+MCP tools that fetch URLs, call webhooks, convert remote documents, or proxy API
+requests give the model network execution authority. If a destination is selected
+from a prompt, retrieved document, tool result, or other untrusted context, an
+attacker may cause the tool to request an unintended internal or privileged
+service. This remains an SSRF risk even when the tool does not execute shell
+commands.
+
+The destination must be validated as data at the tool boundary. A model deciding
+that a URL "looks safe" is not a security control. Validation also has to account
+for redirects, DNS changes between validation and connection, IPv4 and IPv6
+representations, and non-HTTP schemes supported by the underlying client.
+
 ### Impact
 - Arbitrary code execution: Attackers gain the ability to run shell commands, scripts, or binaries on the host system with the agent's privileges.
 - Data exfiltration: Sensitive files, databases, or environment variables can be read and transmitted to attacker-controlled endpoints.
+- Internal service access: Network-enabled tools can reach services that are not exposed to the original user, including administrative APIs and cloud metadata services.
+- Credential exposure: Responses from internal or link-local endpoints can disclose workload credentials, tokens, configuration, or infrastructure details.
 - System compromise: Installation of backdoors, rootkits, or persistent access mechanisms.
 - Privilege escalation: Exploiting SUID binaries, sudo misconfigurations, or service accounts to gain higher-level access.
 - Denial of service: Resource exhaustion through fork bombs, infinite loops, or system shutdowns.
@@ -39,6 +54,11 @@ Your MCP environment is likely vulnerable if:
 - File path operations accept unsanitized input, allowing directory traversal (../../../etc/passwd) or overwriting critical files.
 - API or database calls are constructed using string interpolation rather than parameterized queries or safe APIs.
 - Agent outputs are not constrained to allowlists of permitted commands, arguments, or file paths.
+- URL-fetching or webhook tools accept a complete destination from model-controlled or retrieved content.
+- Destination checks occur only before DNS resolution or only on the first URL in a redirect chain.
+- Outbound tools can connect to loopback, private, link-local, multicast, or otherwise reserved address ranges.
+- The HTTP client accepts unnecessary schemes or automatically follows redirects without revalidation.
+- The MCP server has unrestricted network egress or can directly reach cloud metadata and internal control-plane services.
 - Special characters (;, |, &, $(), backticks, >, <, &&, ||) in agent-generated parameters are not stripped or escaped.
 - Environment variables or secrets can be accessed through command substitution ($VAR, $(cmd), backticks).
 - No runtime sandboxing isolates tool execution from the host system or critical resources.
@@ -74,6 +94,17 @@ Reject unsafe patterns: chained commands, redirection, wildcards, command substi
 Require approval for destructive, privileged, or system-modifying operations.
 Log all tool calls with full parameters and maintain immutable audit trails.
 
+7. Constrain Outbound Network Authority
+- Prefer tool-specific destination identifiers over accepting arbitrary URLs.
+- Allowlist required schemes, hosts, ports, and methods when the business flow has known destinations.
+- Parse and canonicalize destinations with a maintained URL library; do not validate URLs with ad hoc substring or regular-expression checks.
+- Resolve the destination and reject loopback, private, link-local, multicast, unspecified, and other non-public addresses unless a narrowly documented internal destination is explicitly allowed.
+- Disable redirects where possible. Otherwise, repeat destination validation after every redirect and enforce a low redirect limit.
+- Apply the same checks immediately before connection so DNS rebinding cannot change an approved hostname into a prohibited address.
+- Enforce egress policy at the network layer so the tool process can reach only required services. Keep cloud metadata and internal control-plane endpoints unreachable.
+- Do not return raw internal response bodies, headers, or connection errors to the model or user.
+- Apply timeouts, response-size limits, and content-type restrictions to reduce denial-of-service and data-exposure impact.
+
 ### Example Attack Scenarios
 
 #### Scenario 1 — Shell Metacharacter Injection
@@ -91,11 +122,26 @@ SELECT * FROM records WHERE name = 'user'; DROP TABLE users;--'
 The SQL injection destroys the database.
 Mitigation: Always use prepared statements; never interpolate user input into SQL strings.
 
+#### Scenario 3 - Prompt-Directed Internal Request
+An MCP document-conversion tool accepts a URL selected from retrieved content.
+The content instructs the agent to fetch an internal service address. The tool
+can reach that address even though the user cannot, and returns the response to
+the model.
+
+Mitigation: Do not expose arbitrary destinations when a bounded identifier is
+sufficient. Validate the resolved address at connection time, revalidate every
+redirect, block prohibited address ranges, and enforce independent network
+egress controls.
 
 ### Detection
 Unusual commands: Detection of shell metacharacters (;, |, &, backticks) in tool parameters or logs.
 Privilege escalation attempts: Execution of sudo, su, or SUID binaries by agent processes.
 Unexpected network activity: Outbound connections from agent hosts to unknown domains.
+Prohibited destinations: Requests to loopback, private, link-local, metadata, or newly observed destinations.
+Resolution changes: Hostnames that resolve to prohibited ranges, return mixed public/private answers, or change address classification between checks.
+Redirect anomalies: Redirect chains that cross trust boundaries, change scheme or port, or repeatedly approach the configured limit.
+Tool-intent mismatch: Network requests that do not match the initiating tool's documented destination set or user-approved action.
+Response anomalies: Unusual internal headers, credential-shaped values, or unexpectedly large responses returned by URL-fetching tools.
 File system anomalies: Access to sensitive paths (/etc/passwd, /root, /proc/, ~/.ssh).
 Syscall anomalies: Abnormal patterns detected by Falco, auditd, or osquery (e.g., execve with suspicious args).
 High resource consumption: CPU spikes, memory exhaustion, or disk I/O storms indicating malicious scripts.
@@ -107,6 +153,9 @@ Failed validation attempts: Repeated rejections of inputs containing metacharact
 - [Systematic Analysis of MCP Security](https://arxiv.org/html/2508.12538v1) — Academic study finding 82% of MCP implementations use APIs prone to path traversal, 67% to code injection
 - [A Security Engineer's Guide to MCP](https://semgrep.dev/blog/2025/a-security-engineers-guide-to-mcp/) — Semgrep analysis of command injection patterns in MCP tool implementations
 - [MCP Servers: The New Security Nightmare](https://equixly.com/blog/2025/03/29/mcp-server-new-security-nightmare/) — Analysis of shell execution risks in MCP server deployments
-- [MCP Specification — Security Best Practices](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices) — Official guidance on input validation and sandboxing
+- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices) - Official MCP guidance covering SSRF risks and mitigations
+- [OWASP Server-Side Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html) - Application- and network-layer SSRF defenses
+- [CVE-2025-65512](https://nvd.nist.gov/vuln/detail/CVE-2025-65512) - SSRF in an MCP webpage-to-markdown tool involving hostname validation and redirect-chain bypasses
+- [CVE-2025-65513](https://nvd.nist.gov/vuln/detail/CVE-2025-65513) - SSRF in an MCP fetch tool allowing private-IP validation bypass and internal resource access
 
 ### [Make suggestions on Github:- ](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP10-2025%E2%80%93ContextInjection%26OverSharing.md)


### PR DESCRIPTION
## Summary

Adds a focused treatment of tool-mediated server-side request forgery (SSRF) and uncontrolled outbound network authority to MCP05.

## What changed

- explains why URL-fetching, webhook, conversion, and proxy tools are execution surfaces even without shell access;
- adds vulnerability indicators for model-controlled destinations, redirects, DNS rebinding, alternate address representations, and unrestricted egress;
- adds application- and network-layer controls for destination validation, redirect handling, prohibited ranges, egress policy, response handling, and resource limits;
- adds a conservative attack scenario and operational detection signals; and
- cites official MCP security guidance, the OWASP SSRF Prevention Cheat Sheet, and NVD entries CVE-2025-65512 and CVE-2025-65513.

This keeps SSRF as a concrete MCP05 sub-risk while issue #20 considers whether the project wants a different long-term category placement.

## Validation

- `git diff --check` passes.
- All four newly added primary-source links return successfully.
- The repository only runs metadata validation for `*.owasp.yaml`; this change does not modify project metadata.
- `markdownlint-cli2` reports existing style debt throughout this page; the contribution follows the page's current structure and does not reformat unrelated content.

Closes #20