### PR TITLE
MCP09: replace detection guidance that does not match the protocol, a…

### DIFF
--- a/2025/MCP09-2025–Shadow-MCP-Servers.md
+++ b/2025/MCP09-2025–Shadow-MCP-Servers.md
@@ -21,7 +21,8 @@ You may have shadow MCP risk if:
 
 - Teams or developers can deploy MCP servers without central registration or security review.
 - There is no asset inventory or endpoint discovery process for internal APIs or services.
-- Network monitoring tools show unauthorized services running on unusual ports (e.g., 8000, 8080).
+- Network monitoring shows HTTP endpoints answering JSON-RPC POSTs with an `MCP-Protocol-Version` header, on hosts with no registered MCP instance.
+- Client configuration files on managed endpoints reference MCP servers that are not in the registry.
 - There is no automated MCP discovery scan across subnets or cloud environments.
 - MCP configurations are managed independently by individual teams (no unified baseline templates).
 - No governance or change management workflow exists for new AI infrastructure.
@@ -46,6 +47,8 @@ You may have shadow MCP risk if:
 - Publish secure-by-default MCP configuration templates for teams:
 - Enforce authentication and authorization (mTLS, OAuth).
 - Disable unauthenticated tool calls and external access by default.
+- Validate the `Origin` header on every connection and reject invalid origins with 403, to prevent DNS rebinding.
+- Bind local servers to 127.0.0.1 rather than 0.0.0.0.
 - Include preconfigured logging, rate-limits, and monitoring agents.
 - Block deployment of MCP instances that deviate from approved templates.
 
@@ -56,7 +59,7 @@ You may have shadow MCP risk if:
 
 5. Monitor for Anomalous or Unauthorized Behavior
 - Correlate telemetry to identify new MCP-related API traffic or agent activity from unknown hosts.
-- Set up alerts for endpoints responding on MCP-standard routes (/mcp, /agent/tools, /context).
+- Alert on request metadata rather than paths. The `MCP-Protocol-Version` header is required on every Streamable HTTP request and identifies both the traffic and the revision in use. The endpoint path is chosen by the server and cannot be assumed.
 - Track configuration drift and endpoint proliferation over time.
 
 6. Security Awareness & Developer Education
@@ -73,6 +76,11 @@ You may have shadow MCP risk if:
 - Include shadow MCP detection in threat-hunting playbooks.
 - Upon detection, trigger an incident response workflow to contain, image, and analyze the rogue server.
 - Track remediation metrics (mean time to discovery and closure).
+
+9. Inventory stdio Servers from Client Configuration, Not from the Network
+- The stdio transport launches the server as a subprocess of the client, so it exposes no port and no endpoint, and it will never appear in a network scan. Items 2 and 5 above cannot see it.
+- Collect and diff MCP client configuration files across managed endpoints, and treat an unregistered server command there the same as an unregistered listener.
+- Apply the registry requirement in item 1 to stdio servers explicitly. The specification recommends stdio for local use, so it is the default a shadow deployment is most likely to take.
 
 
 
@@ -91,7 +99,7 @@ A research team installs experimental plugins from GitHub into their shadow MCP.
 A rogue MCP pulls experimental data from an external partner API. The dataset contains manipulated entries that later propagate into model retraining pipelines, corrupting production AI outputs.
 
 #### Detection & Remediation
-- Discovery of unregistered hosts exposing /mcp or similar routes.
+- Discovery of unregistered hosts answering JSON-RPC POSTs with MCP request metadata headers, on any path.
 - Unknown certificates or self-signed certs in network scans.
 - Anomalous outbound traffic from R&D subnets.
 - Internal threat-hunting tools detecting MCP API patterns in unexpected zones.

--- a/2025/MCP09-2025–Shadow-MCP-Servers.md
+++ b/2025/MCP09-2025–Shadow-MCP-Servers.md
@@ -125,3 +125,4 @@ A rogue MCP pulls experimental data from an external partner API. The dataset co
 ###### [Make your suggestion on Github - ](https://github.com/OWASP/www-project-mcp-top-10/edit/main/2025/MCP09-2025%E2%80%93Shadow-MCP-Servers.md)
 
 
+

--- a/2025/MCP09-2025–Shadow-MCP-Servers.md
+++ b/2025/MCP09-2025–Shadow-MCP-Servers.md
@@ -59,7 +59,7 @@ You may have shadow MCP risk if:
 
 5. Monitor for Anomalous or Unauthorized Behavior
 - Correlate telemetry to identify new MCP-related API traffic or agent activity from unknown hosts.
-- Alert on request metadata rather than paths. The `MCP-Protocol-Version` header is required on every Streamable HTTP request and identifies both the traffic and the revision in use. The endpoint path is chosen by the server and cannot be assumed.
+- Alert on request metadata rather than paths. The `MCP-Protocol-Version` header is required on every Streamable HTTP request after initialization and identifies both the traffic and the revision in use. Its absence is not conclusive. The initialize request precedes version negotiation, and a server that receives no header assumes protocol version 2025-03-26. The endpoint path is chosen by the server and cannot be assumed.
 - Track configuration drift and endpoint proliferation over time.
 
 6. Security Awareness & Developer Education
@@ -80,7 +80,7 @@ You may have shadow MCP risk if:
 9. Inventory stdio Servers from Client Configuration, Not from the Network
 - The stdio transport launches the server as a subprocess of the client, so it exposes no port and no endpoint, and it will never appear in a network scan. Items 2 and 5 above cannot see it.
 - Collect and diff MCP client configuration files across managed endpoints, and treat an unregistered server command there the same as an unregistered listener.
-- Apply the registry requirement in item 1 to stdio servers explicitly. The specification recommends stdio for local use, so it is the default a shadow deployment is most likely to take.
+- Apply the registry requirement in item 1 to stdio servers explicitly. The specification says "Clients SHOULD support stdio whenever possible", so a shadow deployment can take this transport without ever touching the network.
 
 
 
@@ -123,6 +123,5 @@ A rogue MCP pulls experimental data from an external partner API. The dataset co
 - [Securing the Model Context Protocol: Risks, Controls, and Governance](https://arxiv.org/pdf/2511.20920) — Governance framework addressing unauthorized server proliferation
 
 ###### [Make your suggestion on Github - ](https://github.com/OWASP/www-project-mcp-top-10/edit/main/2025/MCP09-2025%E2%80%93Shadow-MCP-Servers.md)
-
 
 

--- a/2025/MCP09-2025–Shadow-MCP-Servers.md
+++ b/2025/MCP09-2025–Shadow-MCP-Servers.md
@@ -59,7 +59,7 @@ You may have shadow MCP risk if:
 
 5. Monitor for Anomalous or Unauthorized Behavior
 - Correlate telemetry to identify new MCP-related API traffic or agent activity from unknown hosts.
-- Alert on request metadata rather than paths. The `MCP-Protocol-Version` header is required on every Streamable HTTP request after initialization and identifies both the traffic and the revision in use. Its absence is not conclusive. The initialize request precedes version negotiation, and a server that receives no header assumes protocol version 2025-03-26. The endpoint path is chosen by the server and cannot be assumed.
+- Alert on request metadata rather than paths. The `MCP-Protocol-Version` header is required on every Streamable HTTP request after initialization and identifies both the traffic and the revision in use. Its absence is not conclusive, because the initialize request precedes version negotiation and a client on 2025-03-26 may omit the header. The endpoint path is chosen by the server and cannot be assumed.
 - Track configuration drift and endpoint proliferation over time.
 
 6. Security Awareness & Developer Education


### PR DESCRIPTION
Implements what #47 proposed. Five edits to `2025/MCP09-2025–Shadow-MCP-Servers.md`, +11 and -3. Spec citations and the full reasoning are in the issue, so this is the short version.

**Checklist.** The `unusual ports (e.g., 8000, 8080)` line goes. Those are two of the most common development HTTP ports, so a rule written against them fires on nearly every developer machine. MCP reserves no port. The replacement keys on the `MCP-Protocol-Version` header, required on every request after initialization, and a second line covers the client-config surface.

**Prevention step 3.** Adds `Origin` validation and localhost binding to the baseline templates. Both are spec requirements, and neither appeared anywhere in the entry even though the Equixly reference it already cites is the 0.0.0.0 exposure research.

**Prevention step 5.** The `MCP-standard routes (/mcp, /agent/tools, /context)` line goes. The spec leaves the path to the server:

> The server **MUST** provide a single HTTP endpoint path (hereafter referred to as the **MCP endpoint**) that supports both POST and GET methods. For example, this could be a URL like `https://example.com/mcp`.

`/agent/tools` and `/context` are not MCP.

**New item 9, stdio.** The entry doesn't mention the transport at all, and every control in it assumes a network listener. A stdio server is a subprocess of the client. It binds no port. The inventory surface is client configuration files, not subnets. I don't have numbers on how deployments split between stdio and HTTP and I haven't found anyone who has published any, so I'm not claiming this is the common case, only that it is currently uncovered.

**Detection and Remediation.** One line beyond what the issue listed, added for consistency: `exposing /mcp or similar routes` carried the same path assumption as step 5. Drop it if you'd rather keep this to exactly what #47 proposed.

Two things I'd like a view on.

Item 9 is appended rather than folded into item 2, where it arguably belongs, because renumbering 3 through 8 would make the diff much harder to read. I'm not sure which way you'd rather have that trade, so say the word and I'll move it.

Everything is anchored on protocol version 2025-11-25 rather than `/draft/`. The draft revision changes the required header set, and #47 has a note on that, but a published entry should not cite a target that moves.

Disclosure: I run a Streamable HTTP MCP server in production, which is how I ran into this. Nothing here proposes a tool, a product or a link.