### PR TITLE
MCP06: finish the Intent Flow Subversion rename, and fix two wrong footer links

### DIFF
--- a/2025/MCP05-2025–Command-Injection&Execution.md
+++ b/2025/MCP05-2025–Command-Injection&Execution.md
@@ -109,4 +109,4 @@ Failed validation attempts: Repeated rejections of inputs containing metacharact
 - [MCP Servers: The New Security Nightmare](https://equixly.com/blog/2025/03/29/mcp-server-new-security-nightmare/) — Analysis of shell execution risks in MCP server deployments
 - [MCP Specification — Security Best Practices](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices) — Official guidance on input validation and sandboxing
 
-### [Make suggestions on Github:- ](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP10-2025%E2%80%93ContextInjection%26OverSharing.md)
+### [Make suggestions on Github:- ](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP05-2025%E2%80%93Command-Injection%26Execution.md)

--- a/2025/MCP06-2025–Intent-Flow-Subversion.md
+++ b/2025/MCP06-2025–Intent-Flow-Subversion.md
@@ -63,4 +63,4 @@ Your MCP deployment is likely vulnerable if:
 - [mcp-context-protector](https://github.com/trailofbits/mcp-context-protector) — Trail of Bits' open-source security wrapper implementing LLM guardrails for MCP
 - [MCP Security Vulnerabilities: How to Prevent Prompt Injection and Tool Poisoning](https://www.practical-devsecops.com/mcp-security-vulnerabilities/) — Practical DevSecOps guide to intent flow defense
 
-### [Make suggestions on Github](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP06-2025%E2%80%93Prompt-InjectionviaContextual-Payloads.md)
+### [Make suggestions on Github](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP06-2025%E2%80%93Intent-Flow-Subversion.md)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As AI systems become increasingly integrated into software supply chains, enterp
 * MCP03:2025 - [Tool Poisoning](2025/MCP03-2025–Tool-Poisoning)
 * MCP04:2025 - [Software Supply Chain Attacks & Dependency Tampering](2025/MCP04-2025–Software-Supply-Chain-Attacks&Dependency-Tampering)
 * MCP05:2025 - [Command Injection & Execution](2025/MCP05-2025–Command-Injection&Execution)
-* MCP06:2025 - [Prompt Injection via Contextual Payloads](2025/MCP06-2025–Prompt-InjectionviaContextual-Payloads)
+* MCP06:2025 - [Intent Flow Subversion](2025/MCP06-2025–Intent-Flow-Subversion)
 * MCP07:2025 - [Insufficient Authentication & Authorization](2025/MCP07-2025–Insufficient-Authentication&Authorization)
 * MCP08:2025 - [ Lack of Audit and Telemetry](2025/MCP08-2025–Lack-of-Audit-and-Telemetry)
 * MCP09:2025 - [Shadow MCP Servers](2025/MCP09-2025–Shadow-MCP-Servers)
@@ -29,7 +29,7 @@ As AI systems become increasingly integrated into software supply chains, enterp
 | MCP03 - Tool Poisoning | Tool poisoning occurs when an adversary compromises the tools, plugins, or their outputs that an AI model depends on - injecting malicious, misleading, or biased context to manipulate model behavior. |
 | MCP04 - Software Supply Chain Attacks & Dependency Tampering | A compromised dependency can alter agent behavior or introduce execution-level backdoors. |
 | MCP05 - Command Injection & Execution | Command injection occurs when an AI agent constructs and executes system commands, shell scripts, API calls, or code snippets using untrusted input whether from user prompts, retrieved context, or third-party data sources without proper validation or sanitization. |
-| MCP06 - Prompt Injection via Contextual Payloads | This risk is analogous to classic injection attacks (e.g., XSS, SQLi), but in the MCP world the “interpreter” is the model and the “payload” is text (or any content that becomes text after OCR/processing). Because models are designed to follow natural-language instructions, prompt injection attacks are both powerful and subtle. |
+| MCP06 - Intent Flow Subversion | The Model Context Protocol enables agents to retrieve complex context that can act as a secondary instruction channel. Subversion occurs when malicious instructions embedded in context hijack the "Intent Flow," steering the agent away from the user's original goal toward an attacker's objective. |
 | MCP07 -  Insufficient Authentication & Authorization | Inadequate authentication and authorization occur when MCP servers, tools, or agents fail to properly verify identities or enforce access controls during interactions. Since MCP ecosystems often involve multiple agents, users, and services exchanging data and executing actions, weak or missing identity validation exposes critical attack paths. |
 | MCP08 - Lack of Audit and Telemetry | Limited telemetry from MCP servers and agents impedes investigation and incident response. Maintain detailed logs of tool invocations, context changes, and user-agent interactions with immutable audit trails. |
 | MCP09 - Shadow MCP Servers | “Shadow MCP Servers” refer to unapproved or unsupervised deployments of Model Context Protocol instances that operate outside the organization’s formal security governance.Much like Shadow IT, these rogue MCP nodes are often spun up by developers, research teams, or data scientists for experimentation, testing, or convenience frequently using default credentials, permissive configurations, or unsecured APIs. |

--- a/tab_top10.md
+++ b/tab_top10.md
@@ -23,8 +23,8 @@ MCP ecosystems depend on open-source packages, connectors, and model-side plug-i
 ## MCP5:2025 – [Command Injection & Execution](2025/MCP05-2025–Command-Injection&Execution)
 Command injection in MCP environments occurs when an AI agent constructs and executes system commands, shell scripts, API calls, or code snippets using untrusted input—whether from user prompts, retrieved context, or third-party data sources—without proper validation or sanitization.
 
-## MCP6:2025 – [Prompt Injection via Contextual Payloads](2025/MCP06-2025–Prompt-InjectionviaContextual-Payloads)
-This risk is analogous to classic injection attacks (e.g., XSS, SQLi), but in the MCP world the “interpreter” is the model and the “payload” is text (or any content that becomes text after OCR/processing). Because models are designed to follow natural-language instructions, prompt injection attacks are both powerful and subtle.
+## MCP6:2025 – [Intent Flow Subversion](2025/MCP06-2025–Intent-Flow-Subversion)
+The Model Context Protocol enables agents to retrieve complex context that can act as a secondary instruction channel. Subversion occurs when malicious instructions embedded in context hijack the "Intent Flow," steering the agent away from the user's original goal toward an attacker's objective.
 
 ## MCP07:2025 – [Insufficient Authentication & Authorization](2025/MCP07-2025–Insufficient-Authentication&Authorization)
 Inadequate authentication and authorization occur when MCP servers, tools, or agents fail to properly verify identities or enforce access controls during interactions. Since MCP ecosystems often involve multiple agents, users, and services exchanging data and executing actions, weak or missing identity validation exposes critical attack paths.


### PR DESCRIPTION
PR #21 renamed MCP06 from Prompt Injection via Contextual Payloads to Intent Flow Subversion and merged on 2026-02-19. It updated index.md and it added and removed the entry files, but README.md and tab_top10.md were not in that diff, so the old name is still on both of them. This finishes that rename, and it fixes two links that point at the wrong file.

Four changes, four files:

- `tab_top10.md`, MCP06 heading and description now match index.md word for word.
- `README.md`, the same, in the list and in the overview table.
- `2025/MCP06-2025–Intent-Flow-Subversion.md`, the Make suggestions on Github link at the bottom still pointed at the file PR #21 deleted, so it 404s. It points at its own file now.
- `2025/MCP05-2025–Command-Injection&Execution.md`, that link pointed at MCP10's file instead. Also its own now.

What I measured before writing this. The published project page carries eleven distinct links into `2025/`, and exactly one of them answers 404: the old MCP06 path, which comes from tab_top10.md. The README link is dead too, because no file with that name exists in the repo any more. I then checked the same footer link on all ten entry pages. Six point at their own file, MCP02 and MCP09 have no such link at all, and the two in this PR are wrong.

Three things I noticed and left alone, because they're your call rather than mine. `## Data Sources` is an empty heading in index.md and holds only `--` in README.md, and since issue #17 is closed and every entry does carry a References and Further Reading section, I'm not sure it is a gap at all rather than a leftover placeholder. Delete it, or point it at the per-entry references? The `## Road Map` heading in README.md has the Top 10 list under it rather than the roadmap that index.md carries. And the title link on line 3 of README.md nests the smart-contract-top-10 URL inside the correct one.

I run a Streamable HTTP MCP server in production, which is why I was reading these entries line by line to begin with. Nothing here proposes a tool, a product or a link of mine.