### PR TITLE
Strengthen MCP07 identity and OAuth trust boundaries

### DIFF
--- a/2025/MCP07-2025–Insufficient-Authentication&Authorization.md
+++ b/2025/MCP07-2025–Insufficient-Authentication&Authorization.md
@@ -8,17 +8,24 @@ title: "MCP07:2025 – Insufficient Authentication & Authorization"
 ### Description
 Inadequate authentication and authorization occur when MCP servers, tools, or agents fail to properly verify identities or enforce access controls during interactions. Since MCP ecosystems often involve multiple agents, users, and services exchanging data and executing actions, weak or missing identity validation exposes critical attack paths.
 
+An MCP authorization flow can cross four distinct principals: the user, the MCP client, the MCP server, and the downstream resource server or API. A secure design authenticates and authorizes each boundary without treating one bearer token, session cookie, or unverified identity claim as authority for the entire chain. The audit trail should preserve who requested an action, which client and server handled it, who authorized it, and which downstream identity executed it.
+
 ###### Insecure authentication typically manifests as:
 - Missing or optional API key or token validation
 - Hard-coded shared secrets across agents
 - Use of static credentials in configuration files or logs
 - Insecure token issuance (no expiry, weak entropy, or non-scoped tokens)
+- Acceptance of a token that was not issued for the MCP server
+- Token passthrough from the MCP client to a downstream API
+- Missing issuer, audience, resource, expiry, or scope validation
 
 ###### Authorization flaws occur when:
 - Agents or users can perform actions beyond their intended privileges
 - Access control checks rely solely on client-side enforcement
 - MCP servers trust unverified “caller identity” metadata
 - Tool endpoints don’t validate permission scopes per user or agent
+- OAuth proxy servers reuse one static upstream client identity without binding consent to the initiating MCP client
+- Authorization is applied to one endpoint or transport route but omitted from another
 - Together, these weaknesses can lead to unauthorized access, privilege escalation, and data compromise—the same class of issues that historically dominated web and API security, now amplified by autonomous, interconnected agents.
 
 ### Impact
@@ -39,16 +46,21 @@ You are likely exposed if any of the following apply:
 - There is no role-based or attribute-based access control (RBAC / ABAC)
 - Access logs lack identity correlation between agent and user actions
 - Agents can reuse tokens or credentials issued to others
+- The MCP server accepts a token with the wrong audience or forwards the client's token to an upstream API
+- OAuth consent is remembered only for the server's static upstream client ID, allowing a newly registered MCP client to skip meaningful consent
+- Redirect URIs are matched by prefix or pattern instead of exact pre-registration
+- OAuth authorization requests do not bind the response to the initiating client and browser session with a validated `state` value
+- The organization cannot distinguish the requester, authorizer, MCP client, MCP server, and downstream principal in policy decisions and logs
 - No expiration or rotation policies for authentication credentials
 If you cannot determine “who did what, and with what authority”, your system is already vulnerable.
 
 
 ### How to Prevent (Secure Implementation Guidance)
 1. Strong Authentication for All Entities
-- Require mutual TLS (mTLS) between MCP clients, agents, and servers.
-- Use short-lived, scoped tokens (JWT/OAuth2-style) tied to specific sessions and permissions.
-- Enforce token binding to agent identity (e.g., signed agent attestation).
-- Validate every token on the server side — never trust client-provided claims.
+- Authenticate remote HTTP requests using the MCP authorization specification or another approved mechanism appropriate to the deployment. Use mTLS or other sender-constrained tokens where supported and required by the threat model.
+- Use short-lived, scoped tokens tied to the intended resource and permissions.
+- Validate issuer, audience, resource, expiry, and scope on every protected request. Never trust unverified client-provided identity claims.
+- Reject tokens that were not issued for the MCP server. Do not pass an MCP client token through to a downstream API; obtain a separate downstream token for that resource.
 
 2. Implement Fine-Grained Authorization
 - Adopt RBAC (roles) or ABAC (attributes) models: Example: “Agent X may read customer data but not execute tools.”
@@ -59,6 +71,7 @@ If you cannot determine “who did what, and with what authority”, your system
 - Enforce expiration, rotation, and revocation policies for all tokens.
 - Store tokens securely (vaulted or encrypted).
 - Detect and block replayed or duplicated tokens.
+- Keep MCP client grants and downstream credentials separately revocable. Revoking one MCP connection should not require rotating a credential shared by unrelated users or tenants.
 
 4. Least Privilege Principle
 - Minimize agent permissions — assign only what’s needed for the task.
@@ -80,6 +93,19 @@ If you cannot determine “who did what, and with what authority”, your system
 - Prevent local testing servers from exposing endpoints publicly.
 - Enforce environment-specific credentials for dev/test/prod.
 
+8. Bind OAuth Clients, Redirects, and Consent
+- Register and validate exact redirect URIs. Do not use prefix matching or open redirectors.
+- Generate and validate a `state` value for every authorization request and bind it to the initiating MCP client and browser session.
+- Prefer Client ID Metadata Documents for client identification on MCP protocol revision `2026-07-28` and newer. When Dynamic Client Registration is supported for backward compatibility, apply the same client identity, redirect, and consent controls.
+- When an MCP server proxies authorization to a third-party API using a static upstream client ID, obtain consent for each newly introduced MCP client. A remembered consent cookie for the static upstream client is not sufficient proof of consent for a new MCP client.
+- Present the identity of the requesting MCP client and the requested downstream access before authorization.
+
+9. Preserve Identity and Consent Across the Chain
+- Record the requester and authorizer separately when they differ.
+- Bind policy decisions to the MCP client, MCP server, downstream resource, user or service principal, tenant, and operation.
+- Do not replace the user's identity with a shared server identity where downstream authorization or accountability requires user attribution.
+- Include the identity chain, consent decision, policy version, and downstream destination in redacted audit records.
+
 
 
 ### Example Attack Scenarios
@@ -96,24 +122,39 @@ A malicious service registers as a fake MCP agent using an unprotected onboardin
 #### Scenario 4 – Inherited Context Tokens
  An assistant agent inherits the parent’s credentials through shared context, allowing it to execute privileged functions intended only for admins.
 
+#### Scenario 5 – OAuth Proxy Confused Deputy
+An MCP server uses one static OAuth client ID to connect to a third-party API while allowing MCP clients to register dynamically. A user has previously approved the static upstream client, so the authorization server retains a consent cookie. An attacker registers a new MCP client and initiates authorization through the proxy. If the server does not bind the new client to a fresh consent decision and validate the exact redirect and `state`, the attacker may obtain an authorization code without the user meaningfully approving that client.
+
+#### Scenario 6 – Token Passthrough
+An MCP server accepts a bearer token presented by a client without checking that the token was issued for the MCP server. It forwards the token to a downstream API. This bypasses the server's intended request validation, rate limits, and audit boundary, and the downstream service cannot reliably attribute the action to the correct MCP client.
+
 ### Detection
 - Tokens reused across multiple agents or IP addresses.
 - Failed authentication attempts followed by successful privileged actions.
 - Actions performed by unknown or unregistered agent IDs.
 - Sudden increase in unauthorized “403” responses in logs.
 - Tokens used after expiry timestamps.
+- Tokens accepted with an unexpected issuer, audience, or resource.
+- The same client token observed at both the MCP server and a downstream API.
+- New dynamic clients completing authorization without a client-specific consent event.
+- Authorization codes or callbacks that cannot be correlated with a validated `state` value and exact redirect URI.
 
 
 ### Immediate Remediation
 - Revoke all compromised or static tokens immediately.
 - Rotate all service credentials and enforce unique per-agent identities.
 - Enable mTLS and strict API key binding.
+- Stop token passthrough and issue separate audience-bound tokens for the MCP server and downstream resources.
+- Revoke grants issued through unbound OAuth proxy flows and require client-specific consent.
 - Audit existing agents, tools, and connectors for excessive privileges.
 - Review and patch authorization middleware to enforce scope validation.
 - Add temporary compensating controls: IP restrictions, manual approvals for sensitive actions.
 
 ### References & Further Reading
 - [MCP Specification — Security Best Practices](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices) — Official guidance on authentication, authorization, and transport security
+- [MCP Security Best Practices: Confused Deputy and Token Passthrough](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices) — Official attack descriptions and required mitigations
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization) — Authorization requirements for HTTP-based MCP transports in protocol revision 2026-07-28
+- [RFC 9700 — OAuth 2.0 Security Best Current Practice](https://www.rfc-editor.org/rfc/rfc9700) — Redirect URI, authorization response, and token security guidance
 - [MCP Security Vulnerabilities: How to Prevent Prompt Injection and Tool Poisoning](https://www.practical-devsecops.com/mcp-security-vulnerabilities/) — Analysis finding 38% of MCP servers lack authentication entirely
 - [Microsoft & Anthropic MCP Servers at Risk of RCE, Cloud Takeovers](https://www.darkreading.com/application-security/microsoft-anthropic-mcp-servers-risk-takeovers) — Authorization bypass leading to cloud account compromise
 - [Systematic Analysis of MCP Security](https://arxiv.org/html/2508.12538v1) — Academic analysis of authentication and authorization gaps across MCP implementations
@@ -122,6 +163,3 @@ A malicious service registers as a fake MCP agent using an unprotected onboardin
 
 
 ### [Make suggestions on Github ](https://github.com/OWASP/www-project-mcp-top-10/blob/main/2025/MCP07-2025%E2%80%93Insufficient-Authentication%26Authorization.md)
-
-
-


### PR DESCRIPTION
## Summary

This change makes MCP07 more specific to the identity and authorization boundaries present in MCP deployments.

It adds guidance for:

- Distinguishing the user, MCP client, MCP server, and downstream resource server or API
- Rejecting token passthrough and validating issuer, audience, resource, expiry, and scope
- Preventing OAuth proxy confused deputy flows
- Binding dynamic clients, redirects, state, and consent
- Preserving requester, authorizer, client, server, and downstream identity in policy decisions and audit records
- Detecting cross-boundary token reuse and authorization flows that cannot be tied to client-specific consent

## Why

MCP01 covers token and secret handling. MCP07 should own the related authorization boundary: which principal is acting, which resource a token was issued for, who consented, and how that authority is preserved across an MCP server and its downstream services.

This complements #51 without expanding MCP01 into a general identity and OAuth category.

## Scope

Documentation only. The change updates MCP07 and adds protocol-specific scenarios, controls, detection guidance, and primary references.

The guidance is implementation-neutral and does not recommend a specific product, vendor, identity provider, or security tool.

## Validation

- Parsed the changed document as GitHub-flavored Markdown with Pandoc.
- `git diff --check` passes.

## References

- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
- [RFC 9700: OAuth 2.0 Security Best Current Practice](https://www.rfc-editor.org/rfc/rfc9700)
